### PR TITLE
Potential fix for code scanning alert no. 6: Unsafe shell command constructed from library input

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import {getInput, error as core_error, info, setFailed} from '@actions/core'
-import {exec} from 'child_process'
+import {exec, execFile} from 'child_process'
 import {promises} from 'fs'
 import path from 'path'
 import {env} from 'process'
@@ -12,6 +12,7 @@ interface ExecResult {
 }
 type ExecFn = (command: string) => Promise<ExecResult>
 let execAsync: ExecFn = util.promisify(exec) as unknown as ExecFn
+const execFileAsync = util.promisify(execFile)
 export function setExecAsync(fn: ExecFn): void {
 	// test helper to inject mock implementation
 	execAsync = fn
@@ -145,9 +146,9 @@ export async function trySign(file: string): Promise<boolean> {
 				const signCommandResult = await execAsync(command)
 				info(signCommandResult.stdout)
 
-				const verifyCommand = `"${signtool}" verify /pa "${file}"`
-				info(`verifying signing for file: ${file}\nCommand: ${verifyCommand}`)
-				const verifyCommandResult = await execAsync(verifyCommand)
+				const verifyArgs = ['verify', '/pa', file]
+				info(`verifying signing for file: ${file}\nCommand: ${signtool} verify /pa "${file}"`)
+				const verifyCommandResult = await execFileAsync(signtool, verifyArgs)
 				info(verifyCommandResult.stdout)
 
 				return true


### PR DESCRIPTION
Potential fix for [https://github.com/mscrivo/signtool-code-sign/security/code-scanning/6](https://github.com/mscrivo/signtool-code-sign/security/code-scanning/6)

To fix the issue, the shell command should be constructed in a way that prevents shell interpretation of user-supplied data, specifically the `file` parameter. The safest general method is to use `child_process.execFile`, which spawns the intended process directly and passes parameters as an array, avoiding the shell entirely and neutralizing any embedded metacharacters. This should be used in place of `execAsync` for commands that don't require shell features like pipes or redirections. For `signtool verify`, this approach is suitable since the command doesn't use shell operators.

**Changes required:**
- Replace the use of `execAsync(verifyCommand)` with direct use of `execFile` (promisified), providing the command name and arguments separately.
- Update the declaration and use of `execAsync` so that it delegates to a promisified version of `execFile` for this command.
- Import `execFile` from `child_process`.
- No additional package dependencies are required for this solution.

All changes are confined to the file `src/main.ts` and pertain specifically to how the `verifyCommand` is executed in line 150.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
